### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/K2fov/K2onSilicon.py
+++ b/K2fov/K2onSilicon.py
@@ -24,8 +24,8 @@ except ImportError:
     print('You need matplotlib installed to get a plot')
     got_mpl = False
 
-import projection as proj
-import  fov
+from . import projection as proj
+from . import fov
 
 #__version__ = '0.0.1'
 

--- a/K2fov/definefov.py
+++ b/K2fov/definefov.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import numpy as np
 
@@ -47,13 +48,13 @@ def generateVectors():
 
     #Print out the results
     #import pdb; pdb.set_trace()
-    print "["
+    print("[")
     for i in range(len(inFile)):
         ch = channelFromModOut(inFile[i,0], inFile[i,1])
-        print "[%3i., %3i., %3i., %13.7f, %13.7f, %13.7f], \\" %( \
+        print("[%3i., %3i., %3i., %13.7f, %13.7f, %13.7f], \\" %( \
             inFile[i, 0], inFile[i, 1], ch, \
-            origin[i, 0], origin[i, 1], origin[i,2])
-    print "]"
+            origin[i, 0], origin[i, 1], origin[i,2]))
+    print("]")
 
 
 

--- a/K2fov/fov.py
+++ b/K2fov/fov.py
@@ -1,13 +1,15 @@
+from __future__ import print_function
+
 try:
     import matplotlib.pyplot as mp
     import matplotlib
 except ImportError:
     pass
-import projection as proj
+from . import projection as proj
 import numpy as np
-import rotate as r
-import greatcircle as gcircle
-import definefov
+from . import rotate as r
+from . import greatcircle as gcircle
+from . import definefov
 
 
 __version__ = "$Id: fov.py 35 2013-12-19 22:27:34Z fergalm $"
@@ -92,7 +94,7 @@ class KeplerFov():
 
         self.plateScale_arcsecPerPix = 3.98
 
-        self.mods = range(1, 25)
+        self.mods = list(range(1, 25))
         #Remove the 4 FGS mods
         self.mods.pop(0)
         self.mods.pop(3)
@@ -216,7 +218,7 @@ class KeplerFov():
         try:
             ch = self.pickAChannel(ra, dec)
         except ValueError:
-            print "WARN: %.7f %.7f not on any channel" %(ra, dec)
+            print("WARN: %.7f %.7f not on any channel" %(ra, dec))
             return (0,0,0)
 
         col, row = self.getColRowWithinChannel(ra, dec, ch, \

--- a/K2fov/projection.py
+++ b/K2fov/projection.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     pass
 import numpy as np
-import rotate
+from . import rotate
 
 __version__ = "$Id: projection.py 36 2014-01-23 22:19:15Z fergalm $"
 __URL__ = "$URL: http://svn.code.sf.net/p/keplertwowheel/code/py/projection.py $"


### PR DESCRIPTION
These changes allow K2fov to be imported in Python 3.

I verified that it doesn't break anything in my installation of Python 2, but in the absence of unit tests, it would be good for @mrtommyb to check that `runK2onSilicon.py` still runs after merging these changes.
