### PR TITLE
Changes to cope with the failure of Module 4

### DIFF
--- a/K2fov/fov.py
+++ b/K2fov/fov.py
@@ -90,7 +90,7 @@ class KeplerFov():
         # the boresight
         self.defaultMap = None
 
-        self.brokenChannels = [5,6,7,8, 17,18,19,20]
+        self.brokenChannels = [5,6,7,8, 17,18,19,20, 9,10,11,12]  # Mod 3, 7, 4
         self.plateScale_arcsecPerPix = 3.98
 
         self.mods = list(range(1, 25))

--- a/K2fov/tests/test_target_list_on_silicon.py
+++ b/K2fov/tests/test_target_list_on_silicon.py
@@ -14,6 +14,10 @@ def test_targetlists():
     def run_test(campaign):
         """Are entries in the target list of a given campaign on silicon?"""
         fov = getKeplerFov(campaign)
+        if campaign < 11:
+            # Module 4 didn't break until Campaign 10,
+            # whereas Modules 3 and 7 failed before Campaign 0.
+            fov.brokenChannels = [5, 6, 7, 8, 17, 18, 19, 20]
         targetlist_fn = os.path.join(TESTDIR,
                                      "data",
                                      "K2Campaign{0}targets.csv".format(campaign))

--- a/K2fov/version.py
+++ b/K2fov/version.py
@@ -1,3 +1,3 @@
 # It is important to store the version number in a separate file
 # so that we can read it from setup.py without importing the package
-__version__ = "5.0.0"
+__version__ = "5.1.0"


### PR DESCRIPTION
Kepler's CCD Module 4 is thought to have failed on 2016 July 20. This PR captures the changes needed to avoid future PIs from selecting targets on this module.

We should merge the PR and release/announce a new version of K2fov as soon as the failure of Module 4 is confirmed from additional telemetry, which will likely happen by Aug 12.
