### PR TITLE
Import K2fov logger

### DIFF
--- a/K2fov/fov.py
+++ b/K2fov/fov.py
@@ -12,6 +12,7 @@ from . import projection as proj
 from . import rotate2 as r
 from . import greatcircle as gcircle
 from . import definefov
+from . import logger
 
 from . import DEFAULT_PADDING
 
@@ -238,7 +239,7 @@ class KeplerFov():
         row = np.zeros(len(ch))
         for channel in set(ch):
             mask = (ch == channel)
-            col[mask], row[mask] = self.getColRowWithinChannelList(ra[mask], dec[mask], channel, 
+            col[mask], row[mask] = self.getColRowWithinChannelList(ra[mask], dec[mask], channel,
                                                         wantZeroOffset, allowIllegalReturnValues)
         return (ch, col, row)
 


### PR DESCRIPTION
This is needed to create a warning if the target is not on silicon. `logger` is used in the function `getChannelColRow`.